### PR TITLE
fixes all unit actors

### DIFF
--- a/art/actors/units/xion/cavalry_archer_a_m.xml
+++ b/art/actors/units/xion/cavalry_archer_a_m.xml
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant>
-            <mesh>skeletal/horse.dae</mesh>
-            <props>
-                <prop actor="units/xion/cavalry_archer_a_r.xml" attachpoint="rider"/>
-                <prop actor="props/horse/cav_rein_leather.xml" attachpoint="root"/>
-                <prop actor="props/horse/cav_blanket_kush.xml" attachpoint="root"/>
-                <prop actor="props/horse/cav_straps_head_kush.xml" attachpoint="head"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="quadraped/horse/brown.xml" frequency="1" name="brown"/>
-        <variant file="quadraped/horse/dark_chestnut.xml" frequency="1" name="dark_chestnut"/>
-        <variant file="quadraped/horse/fading_black.xml" frequency="1" name="fading_black"/>
-        <variant file="quadraped/horse/gray.xml" frequency="1" name="gray"/>
-        <variant file="quadraped/horse/halflinger.xml" frequency="1" name="halflinger"/>
-    </group>
-    <group>
-        <variant file="quadraped/base_horse_archer.xml" name="Archer-Horse" frequency="1"/>
-        <variant file="quadraped/base_horse_death.xml"/>
-        <variant file="quadraped/base_horse_run.xml"/>
-        <variant file="quadraped/base_horse_gather_meat.xml" name="gather_meat">
-            <props>
-                <prop actor="units/xion/cavalry_archer_a_r.xml" attachpoint="rider_R"/>
-            </props>
-        </variant>
-    </group>
+  <castshadow/>
+  <group>
+    <variant>
+      <mesh>skeletal/horse.dae</mesh>
+      <props>
+        <prop actor="units/xion/cavalry_archer_a_r.xml" attachpoint="rider"/>
+        <prop actor="props/horse/cav_rein_leather.xml" attachpoint="root"/>
+        <prop actor="props/horse/cav_blanket_kush.xml" attachpoint="root"/>
+        <prop actor="props/horse/cav_straps_head_kush.xml" attachpoint="head"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="quadraped/horse/brown.xml" frequency="1" name="brown"/>
+    <variant file="quadraped/horse/dark_chestnut.xml" frequency="1" name="dark_chestnut"/>
+    <variant file="quadraped/horse/fading_black.xml" frequency="1" name="fading_black"/>
+    <variant file="quadraped/horse/gray.xml" frequency="1" name="gray"/>
+    <variant file="quadraped/horse/halflinger.xml" frequency="1" name="halflinger"/>
+  </group>
+  <group>
+    <variant file="quadraped/base_horse_archer.xml" name="Archer-Horse" frequency="1"/>
+    <variant file="quadraped/base_horse_death.xml"/>
+    <variant file="quadraped/base_horse_run.xml"/>
+    <variant file="quadraped/base_horse_gather_meat.xml" name="gather_meat">
+      <props>
+        <prop actor="units/xion/cavalry_archer_a_r.xml" attachpoint="rider_R"/>
+      </props>
+    </variant>
+  </group>
 </actor>

--- a/art/actors/units/xion/cavalry_archer_a_r.xml
+++ b/art/actors/units/xion/cavalry_archer_a_r.xml
@@ -1,56 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant>
-            <mesh>skeletal/new/m_armor_nomad_b.dae</mesh>
-            <props>
-                <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
-                <prop actor="props/units/weapons/bow/xion_cav_bow.xml" attachpoint="weapon_L"/>
-                <prop actor="props/units/quivers/xion_quiver_cavalry_left.xml" attachpoint="sheath_L"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant frequency="2" name="Longhair">
-            <props>
-                <prop actor="" attachpoint="helmet"/>
-                <prop actor="props/units/heads/xion_head_bald_longhair.xml" attachpoint="head"/>
-            </props>
-        </variant>
-        <variant frequency="2" name="Helmet_iron">
-            <props>
-                <prop actor="props/units/helmets/xion_hide_iron.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="6" name="Helmet_cloth">
-            <props>
-                <prop actor="props/units/helmets/xion_cloth.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="6" name="Helmet_b">
-            <props>
-                <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="clothes/xion/uniform_a_01.xml"/>
-        <variant file="clothes/xion/uniform_a_02.xml"/>
-        <variant file="clothes/xion/uniform_a_03.xml"/>
-        <variant file="clothes/xion/uniform_a_04.xml"/>
-    </group>
-    <group>
-        <variant file="biped/rider/cavalry/base_archer_relax_hip.xml" frequency="1" name="relax-hip"/>
-        <variant file="biped/rider/carry_meat.xml"/>
-    </group>
-    <group>
-        <variant frequency="1" name="Idle"/>
-        <variant file="biped/rider/cavalry/attack_ranged_archer_hip.xml"/>
-        <variant file="biped/rider/promotion_shield.xml"/>
-        <variant file="biped/rider/attack_slaughter_shield_xion.xml"/>
-        <variant file="biped/gather_meat.xml"/>
-        <variant file="biped/rider/death_ranged.xml"/>
-    </group>
-    <material>player_trans_spec.xml</material>
+  <castshadow/>
+  <group>
+    <variant>
+      <mesh>skeletal/new/m_armor_nomad_b.dae</mesh>
+      <props>
+        <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
+        <prop actor="props/units/weapons/bow/xion_cav_bow.xml" attachpoint="weapon_bow"/>
+        <prop actor="props/units/quivers/xion_quiver_cavalry_left.xml" attachpoint="sheath_L"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant frequency="2" name="Longhair">
+      <props>
+        <prop actor="" attachpoint="helmet"/>
+        <prop actor="props/units/heads/xion_head_bald_longhair.xml" attachpoint="head"/>
+      </props>
+    </variant>
+    <variant frequency="2" name="Helmet_iron">
+      <props>
+        <prop actor="props/units/helmets/xion_hide_iron.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="6" name="Helmet_cloth">
+      <props>
+        <prop actor="props/units/helmets/xion_cloth.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="6" name="Helmet_b">
+      <props>
+        <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="clothes/xion/uniform_a_01.xml"/>
+    <variant file="clothes/xion/uniform_a_02.xml"/>
+    <variant file="clothes/xion/uniform_a_03.xml"/>
+    <variant file="clothes/xion/uniform_a_04.xml"/>
+  </group>
+  <group>
+    <variant file="biped/rider/cavalry/base_archer_relax_hip.xml" frequency="1" name="relax-hip"/>
+    <variant file="biped/rider/carry_meat.xml"/>
+  </group>
+  <group>
+    <variant frequency="1" name="Idle"/>
+    <variant file="biped/rider/cavalry/attack_ranged_archer_hip.xml"/>
+    <variant file="biped/rider/promotion_shield.xml"/>
+    <variant file="biped/rider/attack_slaughter_shield_xion.xml"/>
+    <variant file="biped/gather_meat.xml"/>
+    <variant file="biped/rider/death_ranged.xml"/>
+  </group>
+  <material>player_trans_spec.xml</material>
 </actor>

--- a/art/actors/units/xion/cavalry_archer_b_m.xml
+++ b/art/actors/units/xion/cavalry_archer_b_m.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant>
-            <mesh>skeletal/horse.dae</mesh>
-            <props>
-                <prop actor="units/xion/cavalry_archer_b_r.xml" attachpoint="rider"/>
-                <prop actor="props/horse/cav_rein_leather.xml" attachpoint="root"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="quadraped/horse/brown.xml" frequency="1" name="brown"/>
-        <variant file="quadraped/horse/dark_chestnut.xml" frequency="1" name="dark_chestnut"/>
-        <variant file="quadraped/horse/fading_black.xml" frequency="1" name="fading_black"/>
-        <variant file="quadraped/horse/gray.xml" frequency="1" name="gray"/>
-        <variant file="quadraped/horse/halflinger.xml" frequency="1" name="halflinger"/>
-    </group>
-    <group>
-        <variant file="quadraped/base_horse_archer.xml" name="Archer-Horse" frequency="1"/>
-        <variant file="quadraped/base_horse_death.xml"/>
-        <variant file="quadraped/base_horse_run.xml"/>
-        <variant file="quadraped/base_horse_gather_meat.xml" name="gather_meat">
-            <props>
-                <prop actor="units/xion/cavalry_archer_b_r.xml" attachpoint="rider_R"/>
-            </props>
-        </variant>
-    </group>
-    <material>objectcolor.xml</material>
+  <castshadow/>
+  <group>
+    <variant>
+      <mesh>skeletal/horse.dae</mesh>
+      <props>
+        <prop actor="units/xion/cavalry_archer_b_r.xml" attachpoint="rider"/>
+        <prop actor="props/horse/cav_rein_leather.xml" attachpoint="root"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="quadraped/horse/brown.xml" frequency="1" name="brown"/>
+    <variant file="quadraped/horse/dark_chestnut.xml" frequency="1" name="dark_chestnut"/>
+    <variant file="quadraped/horse/fading_black.xml" frequency="1" name="fading_black"/>
+    <variant file="quadraped/horse/gray.xml" frequency="1" name="gray"/>
+    <variant file="quadraped/horse/halflinger.xml" frequency="1" name="halflinger"/>
+  </group>
+  <group>
+    <variant file="quadraped/base_horse_archer.xml" name="Archer-Horse" frequency="1"/>
+    <variant file="quadraped/base_horse_death.xml"/>
+    <variant file="quadraped/base_horse_run.xml"/>
+    <variant file="quadraped/base_horse_gather_meat.xml" name="gather_meat">
+      <props>
+        <prop actor="units/xion/cavalry_archer_b_r.xml" attachpoint="rider_R"/>
+      </props>
+    </variant>
+  </group>
+  <material>objectcolor.xml</material>
 </actor>

--- a/art/actors/units/xion/cavalry_archer_b_r.xml
+++ b/art/actors/units/xion/cavalry_archer_b_r.xml
@@ -1,54 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant>
-            <mesh>skeletal/new/m_armor_nomad_a.dae</mesh>
-            <props>
-                <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
-                <prop actor="props/units/weapons/bow/xion_cav_bow.xml" attachpoint="weapon_L"/>
-                <prop actor="props/units/quivers/xion_quiver_cloth_cavalry_left.xml" attachpoint="sheath_L"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="clothes/xion/uniform_b_01.xml"/>
-        <variant file="clothes/xion/uniform_b_02.xml"/>
-        <variant file="clothes/xion/uniform_b_03.xml"/>
-    </group>
-    <group>
-        <variant frequency="15" name="Longhair">
-            <props>
-                <prop actor="props/units/heads/xion_head_bald_longhair.xml" attachpoint="head"/>
-            </props>
-        </variant>
-        <variant frequency="3" name="Helmet_a">
-            <props>
-                <prop actor="props/units/helmets/xion_cloth.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="6" name="No_helmet">
-            <props>
-                <prop actor="" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="2" name="Helmet_b">
-            <props>
-                <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="biped/rider/cavalry/base_archer_relax_hip.xml" frequency="1" name="relax-hip"/>
-        <variant file="biped/rider/carry_meat.xml"/>
-    </group>
-    <group>
-        <variant frequency="1" name="Idle"/>
-        <variant file="biped/rider/cavalry/attack_ranged_archer_hip.xml"/>
-        <variant file="biped/rider/promotion_shield.xml"/>
-        <variant file="biped/rider/attack_slaughter_shield_xion.xml"/>
-        <variant file="biped/gather_meat.xml"/>
-        <variant file="biped/rider/death_ranged.xml"/>
-    </group>
-    <material>player_trans_spec.xml</material>
+  <castshadow/>
+  <group>
+    <variant>
+      <mesh>skeletal/new/m_armor_nomad_a.dae</mesh>
+      <props>
+        <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
+        <prop actor="props/units/weapons/bow/xion_cav_bow.xml" attachpoint="weapon_bow"/>
+        <prop actor="props/units/quivers/xion_quiver_cloth_cavalry_left.xml" attachpoint="sheath_L"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="clothes/xion/uniform_b_01.xml"/>
+    <variant file="clothes/xion/uniform_b_02.xml"/>
+    <variant file="clothes/xion/uniform_b_03.xml"/>
+  </group>
+  <group>
+    <variant frequency="15" name="Longhair">
+      <props>
+        <prop actor="props/units/heads/xion_head_bald_longhair.xml" attachpoint="head"/>
+      </props>
+    </variant>
+    <variant frequency="3" name="Helmet_a">
+      <props>
+        <prop actor="props/units/helmets/xion_cloth.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="6" name="No_helmet">
+      <props>
+        <prop actor="" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="2" name="Helmet_b">
+      <props>
+        <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="biped/rider/cavalry/base_archer_relax_hip.xml" frequency="1" name="relax-hip"/>
+    <variant file="biped/rider/carry_meat.xml"/>
+  </group>
+  <group>
+    <variant frequency="1" name="Idle"/>
+    <variant file="biped/rider/cavalry/attack_ranged_archer_hip.xml"/>
+    <variant file="biped/rider/promotion_shield.xml"/>
+    <variant file="biped/rider/attack_slaughter_shield_xion.xml"/>
+    <variant file="biped/gather_meat.xml"/>
+    <variant file="biped/rider/death_ranged.xml"/>
+  </group>
+  <material>player_trans_spec.xml</material>
 </actor>

--- a/art/actors/units/xion/cavalry_archer_c_m.xml
+++ b/art/actors/units/xion/cavalry_archer_c_m.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant frequency="1" name="Base">
-            <mesh>skeletal/horse.dae</mesh>
-            <props>
-                <prop actor="units/xion/cavalry_archer_c_r.xml" attachpoint="rider"/>
-                <prop actor="props/horse/cav_blanket_xion.xml" attachpoint="root"/>
-                <prop actor="props/horse/cav_rein_leather.xml" attachpoint="root"/>
-            </props>
-        </variant>
-    </group>
-<!--    <group>
+  <castshadow/>
+  <group>
+    <variant frequency="1" name="Base">
+      <mesh>skeletal/horse.dae</mesh>
+      <props>
+        <prop actor="units/xion/cavalry_archer_c_r.xml" attachpoint="rider"/>
+        <prop actor="props/horse/cav_blanket_xion.xml" attachpoint="root"/>
+        <prop actor="props/horse/cav_rein_leather.xml" attachpoint="root"/>
+      </props>
+    </variant>
+  </group>
+  <!--    <group>
         <variant frequency="16" name="black">
             <textures><texture file="skeletal/horse_xion_champion.dds" name="baseTex"/></textures>
         </variant>
@@ -22,16 +22,16 @@
             <textures><texture file="skeletal/horse_xion_champion_c.dds" name="baseTex"/></textures>
         </variant>
     </group>-->
-    <group>
-        <variant file="quadraped/horse/brown.xml" frequency="1" name="brown"/>
-        <variant file="quadraped/horse/dark_chestnut.xml" frequency="1" name="dark_chestnut"/>
-        <variant file="quadraped/horse/fading_black.xml" frequency="1" name="fading_black"/>
-        <variant file="quadraped/horse/gray.xml" frequency="1" name="gray"/>
-        <variant file="quadraped/horse/halflinger.xml" frequency="1" name="halflinger"/>
-    </group>
-    <group>
-        <variant file="quadraped/base_horse_archer.xml" name="Archer-Horse" frequency="1"/>
-        <variant file="quadraped/base_horse_death.xml"/>
-        <variant file="quadraped/base_horse_run.xml"/>
-    </group>
+  <group>
+    <variant file="quadraped/horse/brown.xml" frequency="1" name="brown"/>
+    <variant file="quadraped/horse/dark_chestnut.xml" frequency="1" name="dark_chestnut"/>
+    <variant file="quadraped/horse/fading_black.xml" frequency="1" name="fading_black"/>
+    <variant file="quadraped/horse/gray.xml" frequency="1" name="gray"/>
+    <variant file="quadraped/horse/halflinger.xml" frequency="1" name="halflinger"/>
+  </group>
+  <group>
+    <variant file="quadraped/base_horse_archer.xml" name="Archer-Horse" frequency="1"/>
+    <variant file="quadraped/base_horse_death.xml"/>
+    <variant file="quadraped/base_horse_run.xml"/>
+  </group>
 </actor>

--- a/art/actors/units/xion/cavalry_archer_c_r.xml
+++ b/art/actors/units/xion/cavalry_archer_c_r.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant>
-            <mesh>skeletal/new/m_armor_tunic_short.dae</mesh>
-            <props>
-                <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
-                <prop actor="props/units/weapons/bow/xion_cav_bow.xml" attachpoint="weapon_bow"/>
-                <prop actor="props/units/weapons/sheath/xion_sword_sheath_right.xml" attachpoint="sheath_R"/>
-                <prop actor="props/units/helmets/xion_neck_guard.xml" attachpoint="head"/>
-                <prop actor="props/units/quivers/xion_quiver_cavalry_left.xml" attachpoint="sheath_L"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="clothes/xion/warlord.xml"/>
-    </group>
-    <group>
-        <variant frequency="5" name="Helmet_a">
-            <props>
-                <prop actor="props/units/helmets/xion_warlord.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="biped/rider/cavalry/base_archer_relax_hip.xml" frequency="1" name="relax-hip"/>
-        <variant file="biped/rider/carry_meat.xml"/>
-    </group>
-    <group>
-        <variant frequency="1" name="Idle"/>
-        <variant file="biped/rider/cavalry/attack_ranged_archer_hip.xml"/>
-        <variant file="biped/rider/promotion_shield.xml"/>
-        <variant file="biped/rider/attack_slaughter_shield_xion.xml"/>
-        <variant file="biped/gather_meat.xml"/>
-        <variant file="biped/rider/death_ranged.xml"/>
-    </group>
-    <material>player_trans_spec.xml</material>
+  <castshadow/>
+  <group>
+    <variant>
+      <mesh>skeletal/new/m_armor_tunic_short.dae</mesh>
+      <props>
+        <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
+        <prop actor="props/units/weapons/bow/xion_cav_bow.xml" attachpoint="weapon_bow"/>
+        <prop actor="props/units/weapons/sheath/xion_sword_sheath_right.xml" attachpoint="sheath_R"/>
+        <prop actor="props/units/helmets/xion_neck_guard.xml" attachpoint="head"/>
+        <prop actor="props/units/quivers/xion_quiver_cavalry_left.xml" attachpoint="sheath_L"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="clothes/xion/warlord.xml"/>
+  </group>
+  <group>
+    <variant frequency="5" name="Helmet_a">
+      <props>
+        <prop actor="props/units/helmets/xion_warlord.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="biped/rider/cavalry/base_archer_relax_hip.xml" frequency="1" name="relax-hip"/>
+    <variant file="biped/rider/carry_meat.xml"/>
+  </group>
+  <group>
+    <variant frequency="1" name="Idle"/>
+    <variant file="biped/rider/cavalry/attack_ranged_archer_hip.xml"/>
+    <variant file="biped/rider/promotion_shield.xml"/>
+    <variant file="biped/rider/attack_slaughter_shield_xion.xml"/>
+    <variant file="biped/gather_meat.xml"/>
+    <variant file="biped/rider/death_ranged.xml"/>
+  </group>
+  <material>player_trans_spec.xml</material>
 </actor>

--- a/art/actors/units/xion/cavalry_archer_e_m.xml
+++ b/art/actors/units/xion/cavalry_archer_e_m.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant frequency="1" name="Base">
-            <mesh>skeletal/horse.dae</mesh>
-            <props>
-                <prop actor="units/xion/cavalry_archer_e_r.xml" attachpoint="rider"/>
-                <prop actor="props/horse/cav_blanket_leather_02.xml" attachpoint="root"/>
-                <prop actor="props/horse/cav_straps_head_kush.xml" attachpoint="head"/>
-                <prop actor="props/horse/cav_straps_xion.xml" attachpoint="root"/>
-                <prop actor="props/horse/cav_rein_leather.xml" attachpoint="root"/>
-                <prop actor="props/units/shields/xion_shield_round_cooper.xml" attachpoint="shield"/>
-            </props>
-        </variant>
-    </group>
-<!--    <group>
+  <castshadow/>
+  <group>
+    <variant frequency="1" name="Base">
+      <mesh>skeletal/horse.dae</mesh>
+      <props>
+        <prop actor="units/xion/cavalry_archer_e_r.xml" attachpoint="rider"/>
+        <prop actor="props/horse/cav_blanket_leather_02.xml" attachpoint="root"/>
+        <prop actor="props/horse/cav_straps_head_kush.xml" attachpoint="head"/>
+        <prop actor="props/horse/cav_straps_xion.xml" attachpoint="root"/>
+        <prop actor="props/horse/cav_rein_leather.xml" attachpoint="root"/>
+        <prop actor="props/units/shields/xion_shield_round_cooper.xml" attachpoint="shield"/>
+      </props>
+    </variant>
+  </group>
+  <!--    <group>
         <variant name="No_Shield">
             <props>
                 <prop actor="props/units/shields/xion_shield_round_cooper.xml" attachpoint="shield"/>
@@ -26,7 +26,7 @@
             </props>
         </variant>
     </group>-->
-<!--  <group>
+  <!--  <group>
     <variant frequency="1" name="Horse-Texture-Plain">
       <textures><texture file="skeletal/horse_kart_cjv_b_1.dds" name="baseTex"/></textures>
     </variant>
@@ -37,22 +37,22 @@
       <textures><texture file="skeletal/horse_kart_cjv_b_3.dds" name="baseTex"/></textures>
     </variant>
   </group>-->
-    <group>
-        <variant file="quadraped/horse/brown.xml" frequency="1" name="brown"/>
-        <variant file="quadraped/horse/dark_chestnut.xml" frequency="1" name="dark_chestnut"/>
-        <variant file="quadraped/horse/fading_black.xml" frequency="1" name="fading_black"/>
-        <variant file="quadraped/horse/gray.xml" frequency="1" name="gray"/>
-        <variant file="quadraped/horse/halflinger.xml" frequency="1" name="halflinger"/>
-    </group>
-    <group>
-        <variant file="quadraped/base_horse_archer.xml" name="Archer-Horse" frequency="1"/>
-        <variant file="quadraped/base_horse_death.xml"/>
-        <variant file="quadraped/base_horse_run.xml"/>
-        <variant file="quadraped/base_horse_gather_meat.xml" name="gather_meat">
-            <props>
-                <prop actor="units/xion/cavalry_archer_e_r.xml" attachpoint="rider_R"/>
-            </props>
-        </variant>
-    </group>
-    <material>objectcolor.xml</material>
+  <group>
+    <variant file="quadraped/horse/brown.xml" frequency="1" name="brown"/>
+    <variant file="quadraped/horse/dark_chestnut.xml" frequency="1" name="dark_chestnut"/>
+    <variant file="quadraped/horse/fading_black.xml" frequency="1" name="fading_black"/>
+    <variant file="quadraped/horse/gray.xml" frequency="1" name="gray"/>
+    <variant file="quadraped/horse/halflinger.xml" frequency="1" name="halflinger"/>
+  </group>
+  <group>
+    <variant file="quadraped/base_horse_archer.xml" name="Archer-Horse" frequency="1"/>
+    <variant file="quadraped/base_horse_death.xml"/>
+    <variant file="quadraped/base_horse_run.xml"/>
+    <variant file="quadraped/base_horse_gather_meat.xml" name="gather_meat">
+      <props>
+        <prop actor="units/xion/cavalry_archer_e_r.xml" attachpoint="rider_R"/>
+      </props>
+    </variant>
+  </group>
+  <material>objectcolor.xml</material>
 </actor>

--- a/art/actors/units/xion/cavalry_archer_e_r.xml
+++ b/art/actors/units/xion/cavalry_archer_e_r.xml
@@ -1,57 +1,57 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant frequency="1" name="Shield">
-            <mesh>skeletal/new/m_armor_nomad_e.dae</mesh>
-            <props>
-                <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
-                <prop actor="props/units/weapons/bow/xion_cav_bow.xml" attachpoint="weapon_L"/>
-                <prop actor="props/units/quivers/xion_quiver_cavalry_left.xml" attachpoint="sheath_L"/>
-                <prop actor="props/units/weapons/sheath/xion_sword_sheath_right.xml" attachpoint="sheath_R"/>
-                <prop actor="props/units/shields/xion_shield_round_small_cooper_left_arm.xml" attachpoint="armpad_L"/>
-            </props>
-        </variant>
-        <variant frequency="1" name="No_Shield">
-            <mesh>skeletal/new/m_armor_nomad_e.dae</mesh>
-            <props>
-                <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
-                <prop actor="props/units/weapons/bow/xion_cav_bow.xml" attachpoint="weapon_L"/>
-                <prop actor="props/units/quivers/xion_quiver_cavalry_left.xml" attachpoint="sheath_L"/>
-                <prop actor="props/units/weapons/sheath/xion_sword_sheath_right.xml" attachpoint="sheath_R"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="clothes/xion/uniform_e_01.xml"/>
-        <variant file="clothes/xion/uniform_e_02.xml"/>
-        <variant file="clothes/xion/uniform_e_03.xml"/>
-        <variant file="clothes/xion/uniform_e_04.xml"/>
-        <variant file="clothes/xion/uniform_e_05.xml"/>
-    </group>
-    <group>
-        <variant frequency="1" name="Helmet_a">
-            <props>
-                <prop actor="props/units/helmets/xion_lamellar.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="1" name="Helmet_b">
-            <props>
-                <prop actor="props/units/helmets/xion_iron_padded.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="biped/rider/cavalry/base_archer_relax_hip.xml" frequency="1" name="relax-hip"/>
-        <variant file="biped/rider/carry_meat.xml"/>
-    </group>
-    <group>
-        <variant frequency="1" name="Idle"/>
-        <variant file="biped/rider/cavalry/attack_ranged_archer_hip.xml"/>
-        <variant file="biped/rider/promotion_shield.xml"/>
-        <variant file="biped/rider/attack_slaughter_shield_xion.xml"/>
-        <variant file="biped/gather_meat.xml"/>
-        <variant file="biped/rider/death_ranged.xml"/>
-    </group>
-    <material>player_trans_spec.xml</material>
+  <castshadow/>
+  <group>
+    <variant frequency="1" name="Shield">
+      <mesh>skeletal/new/m_armor_nomad_e.dae</mesh>
+      <props>
+        <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
+        <prop actor="props/units/weapons/bow/xion_cav_bow.xml" attachpoint="weapon_bow"/>
+        <prop actor="props/units/quivers/xion_quiver_cavalry_left.xml" attachpoint="sheath_L"/>
+        <prop actor="props/units/weapons/sheath/xion_sword_sheath_right.xml" attachpoint="sheath_R"/>
+        <prop actor="props/units/shields/xion_shield_round_small_cooper_left_arm.xml" attachpoint="armpad_L"/>
+      </props>
+    </variant>
+    <variant frequency="1" name="No_Shield">
+      <mesh>skeletal/new/m_armor_nomad_e.dae</mesh>
+      <props>
+        <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
+        <prop actor="props/units/weapons/bow/xion_cav_bow.xml" attachpoint="weapon_L"/>
+        <prop actor="props/units/quivers/xion_quiver_cavalry_left.xml" attachpoint="sheath_L"/>
+        <prop actor="props/units/weapons/sheath/xion_sword_sheath_right.xml" attachpoint="sheath_R"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="clothes/xion/uniform_e_01.xml"/>
+    <variant file="clothes/xion/uniform_e_02.xml"/>
+    <variant file="clothes/xion/uniform_e_03.xml"/>
+    <variant file="clothes/xion/uniform_e_04.xml"/>
+    <variant file="clothes/xion/uniform_e_05.xml"/>
+  </group>
+  <group>
+    <variant frequency="1" name="Helmet_a">
+      <props>
+        <prop actor="props/units/helmets/xion_lamellar.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="1" name="Helmet_b">
+      <props>
+        <prop actor="props/units/helmets/xion_iron_padded.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="biped/rider/cavalry/base_archer_relax_hip.xml" frequency="1" name="relax-hip"/>
+    <variant file="biped/rider/carry_meat.xml"/>
+  </group>
+  <group>
+    <variant frequency="1" name="Idle"/>
+    <variant file="biped/rider/cavalry/attack_ranged_archer_hip.xml"/>
+    <variant file="biped/rider/promotion_shield.xml"/>
+    <variant file="biped/rider/attack_slaughter_shield_xion.xml"/>
+    <variant file="biped/gather_meat.xml"/>
+    <variant file="biped/rider/death_ranged.xml"/>
+  </group>
+  <material>player_trans_spec.xml</material>
 </actor>

--- a/art/actors/units/xion/cavalry_swordsman_a_m.xml
+++ b/art/actors/units/xion/cavalry_swordsman_a_m.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant>
-            <mesh>skeletal/horse.dae</mesh>
-            <props>
-                <prop actor="units/xion/cavalry_swordsman_a_r.xml" attachpoint="rider"/>
-                <prop actor="props/horse/cav_rein_leather.xml" attachpoint="root"/>
-                <prop actor="props/horse/cav_blanket_kush.xml" attachpoint="root"/>
-                <prop actor="props/horse/cav_straps_head_kush.xml" attachpoint="head"/>
-            </props>
-        </variant>
-    </group>
-<!--    <group>
+  <castshadow/>
+  <group>
+    <variant>
+      <mesh>skeletal/horse.dae</mesh>
+      <props>
+        <prop actor="units/xion/cavalry_swordsman_a_r.xml" attachpoint="rider"/>
+        <prop actor="props/horse/cav_rein_leather.xml" attachpoint="root"/>
+        <prop actor="props/horse/cav_blanket_kush.xml" attachpoint="root"/>
+        <prop actor="props/horse/cav_straps_head_kush.xml" attachpoint="head"/>
+      </props>
+    </variant>
+  </group>
+  <!--    <group>
         <variant frequency="1" name="rider_relax">
             <props>
                 <prop actor="units/xion/cavalry_swordsman_a_r.xml" attachpoint="rider"/>
@@ -30,21 +30,21 @@
             </props>
         </variant>
     </group>-->
-    <group>
-        <variant file="quadraped/horse/brown.xml" frequency="1" name="brown"/>
-        <variant file="quadraped/horse/dark_chestnut.xml" frequency="1" name="dark_chestnut"/>
-        <variant file="quadraped/horse/fading_black.xml" frequency="1" name="fading_black"/>
-        <variant file="quadraped/horse/gray.xml" frequency="1" name="gray"/>
-        <variant file="quadraped/horse/halflinger.xml" frequency="1" name="halflinger"/>
-    </group>
-    <group>
-        <variant file="quadraped/base_horse_trot.xml" name="Horse-Trot" frequency="1"/>
-        <variant file="quadraped/base_horse_death.xml"/>
-        <variant file="quadraped/base_horse_run.xml"/>
-        <variant file="quadraped/base_horse_gather_meat.xml" name="gather_meat">
-            <props>
-                <prop actor="units/xion/cavalry_swordsman_a_r.xml" attachpoint="rider_R"/>
-            </props>
-        </variant>
-    </group>
+  <group>
+    <variant file="quadraped/horse/brown.xml" frequency="1" name="brown"/>
+    <variant file="quadraped/horse/dark_chestnut.xml" frequency="1" name="dark_chestnut"/>
+    <variant file="quadraped/horse/fading_black.xml" frequency="1" name="fading_black"/>
+    <variant file="quadraped/horse/gray.xml" frequency="1" name="gray"/>
+    <variant file="quadraped/horse/halflinger.xml" frequency="1" name="halflinger"/>
+  </group>
+  <group>
+    <variant file="quadraped/base_horse_trot.xml" name="Horse-Trot" frequency="1"/>
+    <variant file="quadraped/base_horse_death.xml"/>
+    <variant file="quadraped/base_horse_run.xml"/>
+    <variant file="quadraped/base_horse_gather_meat.xml" name="gather_meat">
+      <props>
+        <prop actor="units/xion/cavalry_swordsman_a_r.xml" attachpoint="rider_R"/>
+      </props>
+    </variant>
+  </group>
 </actor>

--- a/art/actors/units/xion/cavalry_swordsman_a_r.xml
+++ b/art/actors/units/xion/cavalry_swordsman_a_r.xml
@@ -1,57 +1,57 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant>
-            <mesh>skeletal/new/m_armor_nomad_a.dae</mesh>
-            <props>
-                <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
-                <prop actor="props/units/weapons/sword/xion_sword.xml" attachpoint="weapon_R"/>
-                <prop actor="props/units/shields/xion_shield_round_small_plaques_left_arm.xml" attachpoint="armpad_L"/>
-            </props>
-            <textures>
-                <texture file="skeletal/xion_advanced_d.png" name="baseTex"/>
-            </textures>
-        </variant>
-    </group>
-    <group>
-        <variant frequency="2" name="Longhair">
-            <props>
-                <prop actor="" attachpoint="helmet"/>
-                <prop actor="props/units/heads/xion_head_bald_longhair.xml" attachpoint="head"/>
-            </props>
-        </variant>
-        <variant frequency="2" name="Helmet_iron">
-            <props>
-                <prop actor="props/units/helmets/xion_hide_iron.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="4" name="Helmet_cloth">
-            <props>
-                <prop actor="props/units/helmets/xion_cloth.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="4" name="Helmet_b">
-            <props>
-                <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="clothes/xion/uniform_a_05.xml"/>
-        <variant file="clothes/xion/uniform_a_06.xml"/>
-        <variant file="clothes/xion/uniform_a_07.xml"/>
-    </group>
-    <group>
-        <variant file="biped/rider/cavalry/base_swordsman_relax_shield.xml" frequency="1" name="relax"/>
-        <variant file="biped/rider/carry_meat.xml"/>
-    </group>
-    <group>
-        <variant frequency="1" name="Idle"/>
-        <variant file="biped/rider/promotion.xml"/>
-        <variant file="biped/rider/attack_slaughter_xion.xml"/>
-        <variant file="biped/gather_meat.xml"/>
-        <variant file="biped/rider/death.xml"/>
-    </group>
-    <material>player_trans_spec.xml</material>
+  <castshadow/>
+  <group>
+    <variant>
+      <mesh>skeletal/new/m_armor_nomad_a.dae</mesh>
+      <props>
+        <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
+        <prop actor="props/units/weapons/sword/xion_sword.xml" attachpoint="weapon_R"/>
+        <prop actor="props/units/shields/xion_shield_round_small_plaques_left_arm.xml" attachpoint="armpad_L"/>
+      </props>
+      <textures>
+        <texture file="skeletal/xion_advanced_d.png" name="baseTex"/>
+      </textures>
+    </variant>
+  </group>
+  <group>
+    <variant frequency="2" name="Longhair">
+      <props>
+        <prop actor="" attachpoint="helmet"/>
+        <prop actor="props/units/heads/xion_head_bald_longhair.xml" attachpoint="head"/>
+      </props>
+    </variant>
+    <variant frequency="2" name="Helmet_iron">
+      <props>
+        <prop actor="props/units/helmets/xion_hide_iron.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="4" name="Helmet_cloth">
+      <props>
+        <prop actor="props/units/helmets/xion_cloth.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="4" name="Helmet_b">
+      <props>
+        <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="clothes/xion/uniform_a_05.xml"/>
+    <variant file="clothes/xion/uniform_a_06.xml"/>
+    <variant file="clothes/xion/uniform_a_07.xml"/>
+  </group>
+  <group>
+    <variant file="biped/rider/cavalry/base_swordsman_relax.xml" frequency="1" name="relax"/>
+    <variant file="biped/rider/carry_meat.xml"/>
+  </group>
+  <group>
+    <variant frequency="1" name="Idle"/>
+    <variant file="biped/rider/promotion.xml"/>
+    <variant file="biped/rider/attack_slaughter_xion.xml"/>
+    <variant file="biped/gather_meat.xml"/>
+    <variant file="biped/rider/death.xml"/>
+  </group>
+  <material>player_trans_spec.xml</material>
 </actor>

--- a/art/actors/units/xion/cavalry_swordsman_a_r_1.xml
+++ b/art/actors/units/xion/cavalry_swordsman_a_r_1.xml
@@ -1,57 +1,57 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant>
-            <mesh>skeletal/new/m_armor_nomad_a.dae</mesh>
-            <props>
-                <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
-                <prop actor="props/units/weapons/sword/xion_sword.xml" attachpoint="weapon_R"/>
-                <prop actor="props/units/shields/xion_shield_round_plaques.xml" attachpoint="shield"/>
-            </props>
-            <textures>
-                <texture file="skeletal/xion_advanced_d.png" name="baseTex"/>
-            </textures>
-        </variant>
-    </group>
-    <group>
-        <variant frequency="2" name="Longhair">
-            <props>
-                <prop actor="" attachpoint="helmet"/>
-                <prop actor="props/units/heads/xion_head_bald_longhair.xml" attachpoint="head"/>
-            </props>
-        </variant>
-        <variant frequency="2" name="Helmet_iron">
-            <props>
-                <prop actor="props/units/helmets/xion_hide_iron.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="4" name="Helmet_cloth">
-            <props>
-                <prop actor="props/units/helmets/xion_cloth.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="4" name="Helmet_b">
-            <props>
-                <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="clothes/xion/uniform_a_05.xml"/>
-        <variant file="clothes/xion/uniform_a_06.xml"/>
-        <variant file="clothes/xion/uniform_a_07.xml"/>
-    </group>
-    <group>
-        <variant file="biped/rider/cavalry/base_swordsman_relax_shield.xml" frequency="1" name="relax"/>
-        <variant file="biped/rider/carry_meat.xml"/>
-    </group>
-    <group>
-        <variant frequency="1" name="Idle"/>
-        <variant file="biped/rider/promotion_shield.xml"/>
-        <variant file="biped/rider/attack_slaughter_shield_xion.xml"/>
-        <variant file="biped/gather_meat.xml"/>
-        <variant file="biped/rider/death_shield.xml"/>
-    </group>
-    <material>player_trans_spec.xml</material>
+  <castshadow/>
+  <group>
+    <variant>
+      <mesh>skeletal/new/m_armor_nomad_a.dae</mesh>
+      <props>
+        <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
+        <prop actor="props/units/weapons/sword/xion_sword.xml" attachpoint="weapon_R"/>
+        <prop actor="props/units/shields/xion_shield_round_plaques.xml" attachpoint="shield"/>
+      </props>
+      <textures>
+        <texture file="skeletal/xion_advanced_d.png" name="baseTex"/>
+      </textures>
+    </variant>
+  </group>
+  <group>
+    <variant frequency="2" name="Longhair">
+      <props>
+        <prop actor="" attachpoint="helmet"/>
+        <prop actor="props/units/heads/xion_head_bald_longhair.xml" attachpoint="head"/>
+      </props>
+    </variant>
+    <variant frequency="2" name="Helmet_iron">
+      <props>
+        <prop actor="props/units/helmets/xion_hide_iron.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="4" name="Helmet_cloth">
+      <props>
+        <prop actor="props/units/helmets/xion_cloth.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="4" name="Helmet_b">
+      <props>
+        <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="clothes/xion/uniform_a_05.xml"/>
+    <variant file="clothes/xion/uniform_a_06.xml"/>
+    <variant file="clothes/xion/uniform_a_07.xml"/>
+  </group>
+  <group>
+    <variant file="biped/rider/cavalry/base_swordsman_relax.xml" frequency="1" name="relax"/>
+    <variant file="biped/rider/carry_meat.xml"/>
+  </group>
+  <group>
+    <variant frequency="1" name="Idle"/>
+    <variant file="biped/rider/promotion_shield.xml"/>
+    <variant file="biped/rider/attack_slaughter_shield_xion.xml"/>
+    <variant file="biped/gather_meat.xml"/>
+    <variant file="biped/rider/death_shield.xml"/>
+  </group>
+  <material>player_trans_spec.xml</material>
 </actor>

--- a/art/actors/units/xion/cavalry_swordsman_b_m.xml
+++ b/art/actors/units/xion/cavalry_swordsman_b_m.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant>
-            <mesh>skeletal/horse.dae</mesh>
-            <props>
-                <prop actor="units/xion/cavalry_swordsman_b_r.xml" attachpoint="rider"/>
-                <prop actor="props/horse/cav_rein_leather.xml" attachpoint="root"/>
-            </props>
-    <!--       <textures><texture file="skeletal/horse_pers_csw_b.dds" name="baseTex"/></textures> -->
-        </variant>
-    </group>
-<!--    <group>
+  <castshadow/>
+  <group>
+    <variant>
+      <mesh>skeletal/horse.dae</mesh>
+      <props>
+        <prop actor="units/xion/cavalry_swordsman_b_r.xml" attachpoint="rider"/>
+        <prop actor="props/horse/cav_rein_leather.xml" attachpoint="root"/>
+      </props>
+      <!--       <textures><texture file="skeletal/horse_pers_csw_b.dds" name="baseTex"/></textures> -->
+    </variant>
+  </group>
+  <!--    <group>
         <variant frequency="1" name="rider_relax">
             <props>
                 <prop actor="units/xion/cavalry_swordsman_b_r.xml" attachpoint="rider"/>
@@ -25,22 +25,22 @@
             </props>
         </variant>
     </group>-->
-    <group>
-        <variant file="quadraped/horse/brown.xml" frequency="1" name="brown"/>
-        <variant file="quadraped/horse/dark_chestnut.xml" frequency="1" name="dark_chestnut"/>
-        <variant file="quadraped/horse/fading_black.xml" frequency="1" name="fading_black"/>
-        <variant file="quadraped/horse/gray.xml" frequency="1" name="gray"/>
-        <variant file="quadraped/horse/halflinger.xml" frequency="1" name="halflinger"/>
-    </group>
-    <group>
-        <variant file="quadraped/base_horse_trot.xml" name="Horse-Trot" frequency="1"/>
-        <variant file="quadraped/base_horse_death.xml"/>
-        <variant file="quadraped/base_horse_run.xml"/>
-        <variant file="quadraped/base_horse_gather_meat.xml" name="gather_meat">
-            <props>
-                <prop actor="units/xion/cavalry_swordsman_b_r.xml" attachpoint="rider_R"/>
-            </props>
-        </variant>
-    </group>
-    <material>objectcolor.xml</material>
+  <group>
+    <variant file="quadraped/horse/brown.xml" frequency="1" name="brown"/>
+    <variant file="quadraped/horse/dark_chestnut.xml" frequency="1" name="dark_chestnut"/>
+    <variant file="quadraped/horse/fading_black.xml" frequency="1" name="fading_black"/>
+    <variant file="quadraped/horse/gray.xml" frequency="1" name="gray"/>
+    <variant file="quadraped/horse/halflinger.xml" frequency="1" name="halflinger"/>
+  </group>
+  <group>
+    <variant file="quadraped/base_horse_trot.xml" name="Horse-Trot" frequency="1"/>
+    <variant file="quadraped/base_horse_death.xml"/>
+    <variant file="quadraped/base_horse_run.xml"/>
+    <variant file="quadraped/base_horse_gather_meat.xml" name="gather_meat">
+      <props>
+        <prop actor="units/xion/cavalry_swordsman_b_r.xml" attachpoint="rider_R"/>
+      </props>
+    </variant>
+  </group>
+  <material>objectcolor.xml</material>
 </actor>

--- a/art/actors/units/xion/cavalry_swordsman_b_r.xml
+++ b/art/actors/units/xion/cavalry_swordsman_b_r.xml
@@ -1,52 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant>
-            <mesh>skeletal/new/m_armor_nomad_b.dae</mesh>
-            <props>
-                <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
-                <prop actor="props/units/weapons/sword/xion_sword.xml" attachpoint="weapon_R"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="clothes/xion/clothes_a.xml"/>
-        <variant file="clothes/xion/clothes_b.xml"/>
-        <variant file="clothes/xion/clothes_c.xml"/>
-    </group>
-    <group>
-        <variant frequency="15" name="Longhair">
-            <props>
-                <prop actor="props/units/heads/xion_head_bald_longhair.xml" attachpoint="head"/>
-            </props>
-        </variant>
-        <variant frequency="3" name="Helmet_a">
-            <props>
-                <prop actor="props/units/helmets/xion_cloth.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="6" name="No_helmet">
-            <props>
-                <prop actor="" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="2" name="Helmet_b">
-            <props>
-                <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="biped/rider/cavalry/base_swordsman_relax_shield.xml" frequency="1" name="relax"/>
-        <variant file="biped/rider/carry_meat.xml"/>
-    </group>
-    <group>
-        <variant frequency="1" name="Idle"/>
-        <variant file="biped/rider/promotion.xml"/>
-        <variant file="biped/rider/attack_slaughter_xion.xml"/>
-        <variant file="biped/gather_meat.xml"/>
-        <variant file="biped/rider/death.xml"/>
-    </group>
-    <material>player_trans_spec.xml</material>
+  <castshadow/>
+  <group>
+    <variant>
+      <mesh>skeletal/new/m_armor_nomad_b.dae</mesh>
+      <props>
+        <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
+        <prop actor="props/units/weapons/sword/xion_sword.xml" attachpoint="weapon_R"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="clothes/xion/clothes_a.xml"/>
+    <variant file="clothes/xion/clothes_b.xml"/>
+    <variant file="clothes/xion/clothes_c.xml"/>
+  </group>
+  <group>
+    <variant frequency="15" name="Longhair">
+      <props>
+        <prop actor="props/units/heads/xion_head_bald_longhair.xml" attachpoint="head"/>
+      </props>
+    </variant>
+    <variant frequency="3" name="Helmet_a">
+      <props>
+        <prop actor="props/units/helmets/xion_cloth.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="6" name="No_helmet">
+      <props>
+        <prop actor="" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="2" name="Helmet_b">
+      <props>
+        <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="biped/rider/cavalry/base_swordsman_relax.xml" frequency="1" name="relax"/>
+    <variant file="biped/rider/carry_meat.xml"/>
+  </group>
+  <group>
+    <variant frequency="1" name="Idle"/>
+    <variant file="biped/rider/promotion.xml"/>
+    <variant file="biped/rider/attack_slaughter_xion.xml"/>
+    <variant file="biped/gather_meat.xml"/>
+    <variant file="biped/rider/death.xml"/>
+  </group>
+  <material>player_trans_spec.xml</material>
 </actor>

--- a/art/actors/units/xion/cavalry_swordsman_b_r_1.xml
+++ b/art/actors/units/xion/cavalry_swordsman_b_r_1.xml
@@ -1,53 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant>
-            <mesh>skeletal/new/m_armor_nomad_b.dae</mesh>
-            <props>
-                <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
-                <prop actor="props/units/weapons/sword/xion_sword.xml" attachpoint="weapon_R"/>
-                <prop actor="props/units/shields/xion_shield_round_leather.xml" attachpoint="shield"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="clothes/xion/clothes_a.xml"/>
-        <variant file="clothes/xion/clothes_b.xml"/>
-        <variant file="clothes/xion/clothes_c.xml"/>
-    </group>
-    <group>
-        <variant frequency="15" name="Longhair">
-            <props>
-                <prop actor="props/units/heads/xion_head_bald_longhair.xml" attachpoint="head"/>
-            </props>
-        </variant>
-        <variant frequency="3" name="Helmet_a">
-            <props>
-                <prop actor="props/units/helmets/xion_cloth.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="6" name="No_helmet">
-            <props>
-                <prop actor="" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="2" name="Helmet_b">
-            <props>
-                <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="biped/rider/cavalry/base_swordsman_relax_shield.xml" frequency="1" name="relax"/>
-        <variant file="biped/rider/carry_meat.xml"/>
-    </group>
-    <group>
-        <variant frequency="1" name="Idle"/>
-        <variant file="biped/rider/promotion_shield.xml"/>
-        <variant file="biped/rider/attack_slaughter_shield_xion.xml"/>
-        <variant file="biped/gather_meat.xml"/>
-        <variant file="biped/rider/death_shield.xml"/>
-    </group>
-    <material>player_trans_spec.xml</material>
+  <castshadow/>
+  <group>
+    <variant>
+      <mesh>skeletal/new/m_armor_nomad_b.dae</mesh>
+      <props>
+        <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
+        <prop actor="props/units/weapons/sword/xion_sword.xml" attachpoint="weapon_R"/>
+        <prop actor="props/units/shields/xion_shield_round_leather.xml" attachpoint="shield"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="clothes/xion/clothes_a.xml"/>
+    <variant file="clothes/xion/clothes_b.xml"/>
+    <variant file="clothes/xion/clothes_c.xml"/>
+  </group>
+  <group>
+    <variant frequency="15" name="Longhair">
+      <props>
+        <prop actor="props/units/heads/xion_head_bald_longhair.xml" attachpoint="head"/>
+      </props>
+    </variant>
+    <variant frequency="3" name="Helmet_a">
+      <props>
+        <prop actor="props/units/helmets/xion_cloth.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="6" name="No_helmet">
+      <props>
+        <prop actor="" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="2" name="Helmet_b">
+      <props>
+        <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="biped/rider/cavalry/base_swordsman_relax.xml" frequency="1" name="relax"/>
+    <variant file="biped/rider/carry_meat.xml"/>
+  </group>
+  <group>
+    <variant frequency="1" name="Idle"/>
+    <variant file="biped/rider/promotion_shield.xml"/>
+    <variant file="biped/rider/attack_slaughter_shield_xion.xml"/>
+    <variant file="biped/gather_meat.xml"/>
+    <variant file="biped/rider/death_shield.xml"/>
+  </group>
+  <material>player_trans_spec.xml</material>
 </actor>

--- a/art/actors/units/xion/cavalry_swordsman_e_m.xml
+++ b/art/actors/units/xion/cavalry_swordsman_e_m.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant>
-            <mesh>skeletal/horse.dae</mesh>
-            <props>
-                <prop actor="props/horse/cav_blanket_leather_02.xml" attachpoint="root"/>
-                <prop actor="props/horse/cav_straps_head_kush.xml" attachpoint="head"/>
-                <prop actor="units/xion/cavalry_swordsman_e_r.xml" attachpoint="rider"/>
-                <prop actor="props/horse/cav_straps_xion.xml" attachpoint="root"/>
-                <prop actor="props/horse/cav_rein_leather.xml" attachpoint="root"/>
-            </props>
-        </variant>
-    </group>
+  <castshadow/>
+  <group>
+    <variant>
+      <mesh>skeletal/horse.dae</mesh>
+      <props>
+        <prop actor="props/horse/cav_blanket_leather_02.xml" attachpoint="root"/>
+        <prop actor="props/horse/cav_straps_head_kush.xml" attachpoint="head"/>
+        <prop actor="units/xion/cavalry_swordsman_e_r.xml" attachpoint="rider"/>
+        <prop actor="props/horse/cav_straps_xion.xml" attachpoint="root"/>
+        <prop actor="props/horse/cav_rein_leather.xml" attachpoint="root"/>
+      </props>
+    </variant>
+  </group>
   <!--  <group>
         <variant frequency="1" name="rider_relax">
             <props>
@@ -33,7 +33,7 @@
             </props>
         </variant>
     </group>-->
-<!--  <group>
+  <!--  <group>
     <variant frequency="1" name="Horse-Texture-Plain">
       <textures><texture file="skeletal/horse_kart_cjv_b_1.dds" name="baseTex"/></textures>
     </variant>
@@ -44,22 +44,22 @@
       <textures><texture file="skeletal/horse_kart_cjv_b_3.dds" name="baseTex"/></textures>
     </variant>
   </group>-->
-    <group>
-        <variant file="quadraped/horse/brown.xml" frequency="1" name="brown"/>
-        <variant file="quadraped/horse/dark_chestnut.xml" frequency="1" name="dark_chestnut"/>
-        <variant file="quadraped/horse/fading_black.xml" frequency="1" name="fading_black"/>
-        <variant file="quadraped/horse/gray.xml" frequency="1" name="gray"/>
-        <variant file="quadraped/horse/halflinger.xml" frequency="1" name="halflinger"/>
-    </group>
-    <group>
-        <variant file="quadraped/base_horse_trot.xml" name="Horse-Trot" frequency="1"/>
-        <variant file="quadraped/base_horse_death.xml"/>
-        <variant file="quadraped/base_horse_run.xml"/>
-        <variant file="quadraped/base_horse_gather_meat.xml" name="gather_meat">
-            <props>
-                <prop actor="units/xion/cavalry_swordsman_e_r.xml" attachpoint="rider_R"/>
-            </props>
-        </variant>
-    </group>
-    <material>objectcolor.xml</material>
+  <group>
+    <variant file="quadraped/horse/brown.xml" frequency="1" name="brown"/>
+    <variant file="quadraped/horse/dark_chestnut.xml" frequency="1" name="dark_chestnut"/>
+    <variant file="quadraped/horse/fading_black.xml" frequency="1" name="fading_black"/>
+    <variant file="quadraped/horse/gray.xml" frequency="1" name="gray"/>
+    <variant file="quadraped/horse/halflinger.xml" frequency="1" name="halflinger"/>
+  </group>
+  <group>
+    <variant file="quadraped/base_horse_trot.xml" name="Horse-Trot" frequency="1"/>
+    <variant file="quadraped/base_horse_death.xml"/>
+    <variant file="quadraped/base_horse_run.xml"/>
+    <variant file="quadraped/base_horse_gather_meat.xml" name="gather_meat">
+      <props>
+        <prop actor="units/xion/cavalry_swordsman_e_r.xml" attachpoint="rider_R"/>
+      </props>
+    </variant>
+  </group>
+  <material>objectcolor.xml</material>
 </actor>

--- a/art/actors/units/xion/cavalry_swordsman_e_r.xml
+++ b/art/actors/units/xion/cavalry_swordsman_e_r.xml
@@ -1,46 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant>
-            <mesh>skeletal/new/m_armor_nomad_e.dae</mesh>
-            <props>
-                <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
-                <prop actor="props/units/weapons/sword/xion_sword.xml" attachpoint="weapon_R"/>
-                <prop actor="props/units/shields/xion_shield_round_cooper_left_arm.xml" attachpoint="armpad_L"/>
-                <prop actor="props/units/weapons/sheath/xion_sword_sheath_left_e.xml" attachpoint="sheath_L"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="clothes/xion/uniform_e_01.xml"/>
-        <variant file="clothes/xion/uniform_e_02.xml"/>
-        <variant file="clothes/xion/uniform_e_03.xml"/>
-        <variant file="clothes/xion/uniform_e_04.xml"/>
-        <variant file="clothes/xion/uniform_e_05.xml"/>
-    </group>
-    <group>
-        <variant frequency="1" name="Helmet_a">
-            <props>
-                <prop actor="props/units/helmets/xion_lamellar.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="1" name="Helmet_b">
-            <props>
-                <prop actor="props/units/helmets/xion_iron_padded.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="biped/rider/cavalry/base_swordsman_relax_shield.xml" frequency="1" name="relax"/>
-        <variant file="biped/rider/carry_meat.xml"/>
-    </group>
-    <group>
-        <variant frequency="1" name="Idle"/>
-        <variant file="biped/rider/promotion.xml"/>
-        <variant file="biped/rider/attack_slaughter_xion.xml"/>
-        <variant file="biped/gather_meat.xml"/>
-        <variant file="biped/rider/death.xml"/>
-    </group>
-    <material>player_trans_spec.xml</material>
+  <castshadow/>
+  <group>
+    <variant>
+      <mesh>skeletal/new/m_armor_nomad_e.dae</mesh>
+      <props>
+        <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
+        <prop actor="props/units/weapons/sword/xion_sword.xml" attachpoint="weapon_R"/>
+        <prop actor="props/units/shields/xion_shield_round_cooper_left_arm.xml" attachpoint="armpad_L"/>
+        <prop actor="props/units/weapons/sheath/xion_sword_sheath_left_e.xml" attachpoint="sheath_L"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="clothes/xion/uniform_e_01.xml"/>
+    <variant file="clothes/xion/uniform_e_02.xml"/>
+    <variant file="clothes/xion/uniform_e_03.xml"/>
+    <variant file="clothes/xion/uniform_e_04.xml"/>
+    <variant file="clothes/xion/uniform_e_05.xml"/>
+  </group>
+  <group>
+    <variant frequency="1" name="Helmet_a">
+      <props>
+        <prop actor="props/units/helmets/xion_lamellar.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="1" name="Helmet_b">
+      <props>
+        <prop actor="props/units/helmets/xion_iron_padded.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="biped/rider/cavalry/base_swordsman_relax.xml" frequency="1" name="relax"/>
+    <variant file="biped/rider/carry_meat.xml"/>
+  </group>
+  <group>
+    <variant frequency="1" name="Idle"/>
+    <variant file="biped/rider/promotion.xml"/>
+    <variant file="biped/rider/attack_slaughter_xion.xml"/>
+    <variant file="biped/gather_meat.xml"/>
+    <variant file="biped/rider/death.xml"/>
+  </group>
+  <material>player_trans_spec.xml</material>
 </actor>

--- a/art/actors/units/xion/cavalry_swordsman_e_r_1.xml
+++ b/art/actors/units/xion/cavalry_swordsman_e_r_1.xml
@@ -1,46 +1,46 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant>
-            <mesh>skeletal/new/m_armor_nomad_e.dae</mesh>
-            <props>
-                <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
-                <prop actor="props/units/weapons/sword/xion_sword.xml" attachpoint="weapon_R"/>
-                <prop actor="props/units/shields/xion_shield_round_cooper.xml" attachpoint="shield"/>
-                <prop actor="props/units/weapons/sheath/xion_sword_sheath_left_e.xml" attachpoint="sheath_L"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="clothes/xion/uniform_e_01.xml"/>
-        <variant file="clothes/xion/uniform_e_02.xml"/>
-        <variant file="clothes/xion/uniform_e_03.xml"/>
-        <variant file="clothes/xion/uniform_e_04.xml"/>
-        <variant file="clothes/xion/uniform_e_05.xml"/>
-    </group>
-    <group>
-        <variant frequency="5" name="Helmet_a">
-            <props>
-                <prop actor="props/units/helmets/xion_lamellar.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="5" name="Helmet_b">
-            <props>
-                <prop actor="props/units/helmets/xion_iron_padded.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="biped/rider/cavalry/base_swordsman_relax_shield.xml" frequency="1" name="relax"/>
-        <variant file="biped/rider/carry_meat.xml"/>
-    </group>
-    <group>
-        <variant frequency="1" name="Idle"/>
-        <variant file="biped/rider/promotion_shield.xml"/>
-        <variant file="biped/rider/attack_slaughter_shield_xion.xml"/>
-        <variant file="biped/gather_meat.xml"/>
-        <variant file="biped/rider/death_shield.xml"/>
-    </group>
-    <material>player_trans_spec.xml</material>
+  <castshadow/>
+  <group>
+    <variant>
+      <mesh>skeletal/new/m_armor_nomad_e.dae</mesh>
+      <props>
+        <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
+        <prop actor="props/units/weapons/sword/xion_sword.xml" attachpoint="weapon_R"/>
+        <prop actor="props/units/shields/xion_shield_round_cooper.xml" attachpoint="shield"/>
+        <prop actor="props/units/weapons/sheath/xion_sword_sheath_left_e.xml" attachpoint="sheath_L"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="clothes/xion/uniform_e_01.xml"/>
+    <variant file="clothes/xion/uniform_e_02.xml"/>
+    <variant file="clothes/xion/uniform_e_03.xml"/>
+    <variant file="clothes/xion/uniform_e_04.xml"/>
+    <variant file="clothes/xion/uniform_e_05.xml"/>
+  </group>
+  <group>
+    <variant frequency="5" name="Helmet_a">
+      <props>
+        <prop actor="props/units/helmets/xion_lamellar.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="5" name="Helmet_b">
+      <props>
+        <prop actor="props/units/helmets/xion_iron_padded.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="biped/rider/cavalry/base_swordsman_relax.xml" frequency="1" name="relax"/>
+    <variant file="biped/rider/carry_meat.xml"/>
+  </group>
+  <group>
+    <variant frequency="1" name="Idle"/>
+    <variant file="biped/rider/promotion_shield.xml"/>
+    <variant file="biped/rider/attack_slaughter_shield_xion.xml"/>
+    <variant file="biped/gather_meat.xml"/>
+    <variant file="biped/rider/death_shield.xml"/>
+  </group>
+  <material>player_trans_spec.xml</material>
 </actor>

--- a/art/actors/units/xion/infantry_archer_a.xml
+++ b/art/actors/units/xion/infantry_archer_a.xml
@@ -1,70 +1,78 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant file="biped/base_archer_ready.xml" frequency="1">
-            <mesh>skeletal/new/m_armor_nomad_b.dae</mesh>
-            <props>
-                <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
-                <prop actor="props/units/weapons/arrow/xion_arrow_back.xml" attachpoint="weapon_R"/>
-                <prop actor="props/units/weapons/bow/xion_bow.xml" attachpoint="weapon_L"/>
-                <prop actor="props/units/quivers/xion_quiver.xml" attachpoint="sheath_L"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant frequency="2" name="Longhair">
-            <props>
-                <prop actor="" attachpoint="helmet"/>
-                <prop actor="props/units/heads/xion_head_bald_longhair.xml" attachpoint="head"/>
-            </props>
-        </variant>
-        <variant frequency="2" name="Helmet_Hide">
-            <props>
-                <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="6" name="Helmet_iron">
-            <props>
-                <prop actor="props/units/helmets/xion_hide_iron.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="6" name="Helmet_b">
-            <props>
-                <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="clothes/xion/uniform_a_01.xml"/>
-        <variant file="clothes/xion/uniform_a_02.xml"/>
-        <variant file="clothes/xion/uniform_a_03.xml"/>
-        <variant file="clothes/xion/uniform_a_04.xml"/>
-    </group>
-    <group>
-        <variant file="biped/base_archer_ready.xml"/>
-        <variant file="biped/carry_food.xml"/>
-        <variant file="biped/carry_meat.xml"/>
-        <variant file="biped/carry_wood.xml"/>
-        <variant file="biped/carry_stone.xml"/>
-        <variant file="biped/carry_metal.xml"/>
-    </group>
-    <group>
-        <variant frequency="1" name="Idle"/>
-        <variant file="biped/attack_ranged_archer_hip.xml"/>
-        <variant file="biped/attack_capture.xml"/>
-        <variant file="biped/attack_slaughter.xml"/>
-        <variant file="biped/gather_tree.xml"/>
-        <variant file="biped/gather_grain.xml"/>
-        <variant file="biped/gather_fruit.xml"/>
-        <variant file="biped/gather_meat.xml"/>
-        <variant file="biped/gather_rock.xml"/>
-        <variant file="biped/gather_ore.xml"/>
-        <variant file="biped/gather_ruins.xml"/>
-        <variant file="biped/gather_praise.xml"/>
-        <variant file="biped/build.xml"/>
-        <variant file="biped/build_farm.xml"/>
-        <variant file="biped/death_infantry.xml"/>
-    </group>
-    <material>player_trans_spec.xml</material>
+  <castshadow/>
+  <group>
+    <variant file="biped/base_archer_ready.xml" frequency="1">
+      <mesh>skeletal/new/m_armor_nomad_b.dae</mesh>
+      <props>
+        <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
+        <prop actor="props/units/weapons/arrow/xion_arrow_back.xml" attachpoint="weapon_R"/>
+        <prop actor="props/units/weapons/bow/xion_bow.xml" attachpoint="weapon_bow"/>
+        <prop actor="props/units/quivers/xion_quiver.xml" attachpoint="sheath_L"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant frequency="2" name="Longhair">
+      <props>
+        <prop actor="" attachpoint="helmet"/>
+        <prop actor="props/units/heads/xion_head_bald_longhair.xml" attachpoint="head"/>
+      </props>
+    </variant>
+    <variant frequency="2" name="Helmet_Hide">
+      <props>
+        <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="6" name="Helmet_iron">
+      <props>
+        <prop actor="props/units/helmets/xion_hide_iron.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="6" name="Helmet_b">
+      <props>
+        <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="clothes/xion/uniform_a_01.xml"/>
+    <variant file="clothes/xion/uniform_a_02.xml"/>
+    <variant file="clothes/xion/uniform_a_03.xml"/>
+    <variant file="clothes/xion/uniform_a_04.xml"/>
+  </group>
+  <group>
+    <variant file="biped/base_archer_ready.xml"/>
+    <variant file="biped/carry_food.xml"/>
+    <variant file="biped/carry_meat.xml"/>
+    <variant file="biped/carry_wood.xml"/>
+    <variant file="biped/carry_stone.xml"/>
+    <variant file="biped/carry_metal.xml"/>
+    <variant file="biped/approach_tree.xml"/>
+    <variant file="biped/approach_grain.xml"/>
+    <variant file="biped/approach_fruit.xml"/>
+    <variant file="biped/approach_meat.xml"/>
+    <variant file="biped/approach_rock.xml"/>
+    <variant file="biped/approach_ore.xml"/>
+    <variant file="biped/approach_ruins.xml"/>
+    <variant file="biped/approach_praise.xml"/>
+  </group>
+  <group>
+    <variant frequency="1" name="Idle"/>
+    <variant file="biped/attack_ranged_archer_hip.xml"/>
+    <variant file="biped/attack_capture.xml"/>
+    <variant file="biped/attack_slaughter.xml"/>
+    <variant file="biped/gather_tree.xml"/>
+    <variant file="biped/gather_grain.xml"/>
+    <variant file="biped/gather_fruit.xml"/>
+    <variant file="biped/gather_meat.xml"/>
+    <variant file="biped/gather_rock.xml"/>
+    <variant file="biped/gather_ore.xml"/>
+    <variant file="biped/gather_ruins.xml"/>
+    <variant file="biped/gather_praise.xml"/>
+    <variant file="biped/build.xml"/>
+    <variant file="biped/build_farm.xml"/>
+    <variant file="biped/death_infantry.xml"/>
+  </group>
+  <material>player_trans_spec.xml</material>
 </actor>

--- a/art/actors/units/xion/infantry_archer_b.xml
+++ b/art/actors/units/xion/infantry_archer_b.xml
@@ -3,70 +3,78 @@
   <castshadow/>
   <group>
     <variant>
-		<mesh>skeletal/new/m_armor_nomad_b.dae</mesh>
+      <mesh>skeletal/new/m_armor_nomad_b.dae</mesh>
       <props>
         <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
         <prop actor="props/units/weapons/arrow/xion_arrow_back.xml" attachpoint="weapon_R"/>
-        <prop actor="props/units/weapons/bow/xion_bow.xml" attachpoint="weapon_L"/>
+        <prop actor="props/units/weapons/bow/xion_bow.xml" attachpoint="weapon_bow"/>
         <prop actor="props/units/quivers/xion_quiver_cloth.xml" attachpoint="sheath_L"/>
       </props>
     </variant>
   </group>
-    <group>
-        <variant file="clothes/xion/clothes_a.xml"/>
-        <variant file="clothes/xion/clothes_b.xml"/>
-        <variant file="clothes/xion/clothes_c.xml"/>
-    </group>
-    <group>
-        <variant frequency="15" name="Longhair">
-            <props>
-                <prop actor="props/units/heads/xion_head_bald_longhair.xml" attachpoint="head"/>
-            </props>
-        </variant>
-        <variant frequency="3" name="Helmet_a">
-            <props>
-                <prop actor="props/units/helmets/xion_cloth.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="6" name="No_helmet">
-            <props>
-                <prop actor="" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="2" name="Helmet_b">
-            <props>
-                <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="biped/base_archer_ready.xml"/>
-        <variant file="biped/carry_food.xml"/>
-        <variant file="biped/carry_meat.xml"/>
-        <variant file="biped/carry_wood.xml"/>
-        <variant file="biped/carry_stone.xml"/>
-        <variant file="biped/carry_metal.xml"/>
-    </group>
-    <group>
-        <variant frequency="1" name="Idle"/>
-        <variant file="biped/attack_ranged_archer_hip.xml"/>
-        <variant file="biped/attack_capture.xml"/>
-        <variant file="biped/attack_slaughter.xml"/>
-        <variant file="biped/gather_tree.xml"/>
-        <variant file="biped/gather_grain.xml"/>
-        <variant file="biped/gather_fruit.xml"/>
-        <variant file="biped/gather_meat.xml">
-            <props>
-                <prop actor="props/units/weapons/bow/xion_bow_back.xml" attachpoint="quiver_back"/>
-            </props>
-        </variant>
-        <variant file="biped/gather_rock.xml"/>
-        <variant file="biped/gather_ore.xml"/>
-        <variant file="biped/gather_ruins.xml"/>
-        <variant file="biped/gather_praise.xml"/>
-        <variant file="biped/build.xml"/>
-        <variant file="biped/build_farm.xml"/>
-        <variant file="biped/death_infantry.xml"/>
-    </group>
-    <material>player_trans.xml</material>
+  <group>
+    <variant file="clothes/xion/clothes_a.xml"/>
+    <variant file="clothes/xion/clothes_b.xml"/>
+    <variant file="clothes/xion/clothes_c.xml"/>
+  </group>
+  <group>
+    <variant frequency="15" name="Longhair">
+      <props>
+        <prop actor="props/units/heads/xion_head_bald_longhair.xml" attachpoint="head"/>
+      </props>
+    </variant>
+    <variant frequency="3" name="Helmet_a">
+      <props>
+        <prop actor="props/units/helmets/xion_cloth.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="6" name="No_helmet">
+      <props>
+        <prop actor="" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="2" name="Helmet_b">
+      <props>
+        <prop actor="props/units/helmets/xion_hide.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="biped/base_archer_ready.xml"/>
+    <variant file="biped/carry_food.xml"/>
+    <variant file="biped/carry_meat.xml"/>
+    <variant file="biped/carry_wood.xml"/>
+    <variant file="biped/carry_stone.xml"/>
+    <variant file="biped/carry_metal.xml"/>
+    <variant file="biped/approach_tree.xml"/>
+    <variant file="biped/approach_grain.xml"/>
+    <variant file="biped/approach_fruit.xml"/>
+    <variant file="biped/approach_meat.xml"/>
+    <variant file="biped/approach_rock.xml"/>
+    <variant file="biped/approach_ore.xml"/>
+    <variant file="biped/approach_ruins.xml"/>
+    <variant file="biped/approach_praise.xml"/>
+  </group>
+  <group>
+    <variant frequency="1" name="Idle"/>
+    <variant file="biped/attack_ranged_archer_hip.xml"/>
+    <variant file="biped/attack_capture.xml"/>
+    <variant file="biped/attack_slaughter.xml"/>
+    <variant file="biped/gather_tree.xml"/>
+    <variant file="biped/gather_grain.xml"/>
+    <variant file="biped/gather_fruit.xml"/>
+    <variant file="biped/gather_meat.xml">
+      <props>
+        <prop actor="props/units/weapons/bow/xion_bow_back.xml" attachpoint="quiver_back"/>
+      </props>
+    </variant>
+    <variant file="biped/gather_rock.xml"/>
+    <variant file="biped/gather_ore.xml"/>
+    <variant file="biped/gather_ruins.xml"/>
+    <variant file="biped/gather_praise.xml"/>
+    <variant file="biped/build.xml"/>
+    <variant file="biped/build_farm.xml"/>
+    <variant file="biped/death_infantry.xml"/>
+  </group>
+  <material>player_trans_spec.xml</material>
 </actor>

--- a/art/actors/units/xion/infantry_archer_e.xml
+++ b/art/actors/units/xion/infantry_archer_e.xml
@@ -1,66 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
 <actor version="1">
-    <castshadow/>
-    <group>
-        <variant frequency="1">
-            <mesh>skeletal/new/m_armor_nomad_e.dae</mesh>
-            <props>
-                <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
-                <prop actor="props/units/weapons/arrow/xion_arrow_back.xml" attachpoint="weapon_R"/>
-                <prop actor="props/units/weapons/bow/xion_bow.xml" attachpoint="weapon_L"/>
-                <prop actor="props/units/quivers/xion_quiver.xml" attachpoint="sheath_L"/>
-                <prop actor="props/units/weapons/sheath/xion_sword_sheath_right.xml" attachpoint="sheath_R"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant frequency="1" name="Helmet_a">
-            <props>
-                <prop actor="props/units/helmets/xion_archer_leather.xml" attachpoint="helmet"/>
-                <prop actor="props/units/helmets/xion_archer_leather_hair.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-        <variant frequency="1" name="Helmet_b">
-            <props>
-                <prop actor="props/units/helmets/xion_iron_padded_b.xml" attachpoint="helmet"/>
-            </props>
-        </variant>
-    </group>
-    <group>
-        <variant file="clothes/xion/uniform_e_01.xml"/>
-        <variant file="clothes/xion/uniform_e_02.xml"/>
-        <variant file="clothes/xion/uniform_e_03.xml"/>
-        <variant file="clothes/xion/uniform_e_04.xml"/>
-        <variant file="clothes/xion/uniform_e_05.xml"/>
-    </group>
-    <group>
-        <variant file="biped/base_archer_ready.xml"/>
-        <variant file="biped/carry_food.xml"/>
-        <variant file="biped/carry_meat.xml"/>
-        <variant file="biped/carry_wood.xml"/>
-        <variant file="biped/carry_stone.xml"/>
-        <variant file="biped/carry_metal.xml"/>
-    </group>
-    <group>
-        <variant frequency="1" name="Idle"/>
-        <variant file="biped/attack_ranged_archer_hip.xml"/>
-        <variant file="biped/attack_capture.xml"/>
-        <variant file="biped/attack_slaughter.xml"/>
-        <variant file="biped/gather_tree.xml"/>
-        <variant file="biped/gather_grain.xml"/>
-        <variant file="biped/gather_fruit.xml"/>
-        <variant file="biped/gather_meat.xml">
-            <props>
-                <prop actor="props/units/weapons/bow/xion_bow_back.xml" attachpoint="quiver_back"/>
-            </props>
-        </variant>
-        <variant file="biped/gather_rock.xml"/>
-        <variant file="biped/gather_ore.xml"/>
-        <variant file="biped/gather_ruins.xml"/>
-        <variant file="biped/gather_praise.xml"/>
-        <variant file="biped/build.xml"/>
-        <variant file="biped/build_farm.xml"/>
-        <variant file="biped/death_infantry.xml"/>
-    </group>
-    <material>player_trans_spec.xml</material>
+  <castshadow/>
+  <group>
+    <variant frequency="1">
+      <mesh>skeletal/new/m_armor_nomad_e.dae</mesh>
+      <props>
+        <prop actor="props/units/heads/xion_head.xml" attachpoint="head"/>
+        <prop actor="props/units/weapons/arrow/xion_arrow_back.xml" attachpoint="weapon_R"/>
+        <prop actor="props/units/weapons/bow/xion_bow.xml" attachpoint="weapon_bow"/>
+        <prop actor="props/units/quivers/xion_quiver.xml" attachpoint="sheath_L"/>
+        <prop actor="props/units/weapons/sheath/xion_sword_sheath_right.xml" attachpoint="sheath_R"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant frequency="1" name="Helmet_a">
+      <props>
+        <prop actor="props/units/helmets/xion_archer_leather.xml" attachpoint="helmet"/>
+        <prop actor="props/units/helmets/xion_archer_leather_hair.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+    <variant frequency="1" name="Helmet_b">
+      <props>
+        <prop actor="props/units/helmets/xion_iron_padded_b.xml" attachpoint="helmet"/>
+      </props>
+    </variant>
+  </group>
+  <group>
+    <variant file="clothes/xion/uniform_e_01.xml"/>
+    <variant file="clothes/xion/uniform_e_02.xml"/>
+    <variant file="clothes/xion/uniform_e_03.xml"/>
+    <variant file="clothes/xion/uniform_e_04.xml"/>
+    <variant file="clothes/xion/uniform_e_05.xml"/>
+  </group>
+  <group>
+    <variant file="biped/base_archer_ready.xml"/>
+    <variant file="biped/carry_food.xml"/>
+    <variant file="biped/carry_meat.xml"/>
+    <variant file="biped/carry_wood.xml"/>
+    <variant file="biped/carry_stone.xml"/>
+    <variant file="biped/carry_metal.xml"/>
+    <variant file="biped/approach_tree.xml"/>
+    <variant file="biped/approach_grain.xml"/>
+    <variant file="biped/approach_fruit.xml"/>
+    <variant file="biped/approach_meat.xml"/>
+    <variant file="biped/approach_rock.xml"/>
+    <variant file="biped/approach_ore.xml"/>
+    <variant file="biped/approach_ruins.xml"/>
+    <variant file="biped/approach_praise.xml"/>
+  </group>
+  <group>
+    <variant frequency="1" name="Idle"/>
+    <variant file="biped/attack_ranged_archer_hip.xml"/>
+    <variant file="biped/attack_capture.xml"/>
+    <variant file="biped/attack_slaughter.xml"/>
+    <variant file="biped/gather_tree.xml"/>
+    <variant file="biped/gather_grain.xml"/>
+    <variant file="biped/gather_fruit.xml"/>
+    <variant file="biped/gather_meat.xml">
+      <props>
+        <prop actor="props/units/weapons/bow/xion_bow_back.xml" attachpoint="quiver_back"/>
+      </props>
+    </variant>
+    <variant file="biped/gather_rock.xml"/>
+    <variant file="biped/gather_ore.xml"/>
+    <variant file="biped/gather_ruins.xml"/>
+    <variant file="biped/gather_praise.xml"/>
+    <variant file="biped/build.xml"/>
+    <variant file="biped/build_farm.xml"/>
+    <variant file="biped/death_infantry.xml"/>
+  </group>
+  <material>player_trans_spec.xml</material>
 </actor>

--- a/art/skeletons/xion_bow.xml
+++ b/art/skeletons/xion_bow.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='utf-8'?>
+<skeletons>
+  <standard_skeleton id="HeleBow" title="HeleBow">
+    <bone name="string" />
+    <bone name="base" />
+    <bone name="topBranch" />
+    <bone name="botBranch" />
+  </standard_skeleton>
+  <skeleton target="HeleBow" title="HeleBow">
+    <identifier>
+      <root>string</root>
+    </identifier>
+    <bone name="string">
+      <target>string</target>
+    </bone>
+    <bone name="base">
+      <target>base</target>
+    </bone>
+    <bone name="topBranch">
+      <target>topBranch</target>
+    </bone>
+    <bone name="botBranch">
+      <target>botBranch</target>
+    </bone>
+  </skeleton>
+</skeletons>

--- a/art/variants/clothes/xion/clothes_a.xml
+++ b/art/variants/clothes/xion/clothes_a.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <variant frequency="1" name="clothes-a">
-    <textures>
-        <texture file="skeletal/xion_cloth_a.png" name="baseTex"/>
-        <texture file="skeletal/xion_cloth_norm.png" name="specTex"/>
-        <texture file="skeletal/xion_cloth_spec.png" name="normTex"/>
-    </textures>
+  <textures>
+    <texture file="skeletal/xion_cloth_a.png" name="baseTex"/>
+    <texture file="skeletal/xion_cloth_norm.png" name="normTex"/>
+    <texture file="skeletal/xion_cloth_spec.png" name="specTex"/>
+  </textures>
 </variant>

--- a/art/variants/clothes/xion/clothes_b.xml
+++ b/art/variants/clothes/xion/clothes_b.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <variant frequency="1" name="brown dark">
-    <textures>
-        <texture file="skeletal/xion_cloth_b.png" name="baseTex"/>
-        <texture file="skeletal/xion_cloth_norm.png" name="specTex"/>
-        <texture file="skeletal/xion_cloth_spec.png" name="normTex"/>
-    </textures>
+  <textures>
+    <texture file="skeletal/xion_cloth_b.png" name="baseTex"/>
+    <texture file="skeletal/xion_cloth_norm.png" name="normTex"/>
+    <texture file="skeletal/xion_cloth_spec.png" name="specTex"/>
+  </textures>
 </variant>

--- a/art/variants/clothes/xion/clothes_c.xml
+++ b/art/variants/clothes/xion/clothes_c.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <variant frequency="1" name="brown light">
-    <textures>
-        <texture file="skeletal/xion_cloth_c.png" name="baseTex"/>
-        <texture file="skeletal/xion_cloth_norm.png" name="specTex"/>
-        <texture file="skeletal/xion_cloth_spec.png" name="normTex"/>
-    </textures>
+  <textures>
+    <texture file="skeletal/xion_cloth_c.png" name="baseTex"/>
+    <texture file="skeletal/xion_cloth_norm.png" name="normTex"/>
+    <texture file="skeletal/xion_cloth_spec.png" name="specTex"/>
+  </textures>
 </variant>

--- a/art/variants/clothes/xion/uniform_a_03.xml
+++ b/art/variants/clothes/xion/uniform_a_03.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <variant frequency="1" name="Cloth_G">
-    <textures>
-        <texture file="skeletal/xion_advanced_g.png" name="baseTex"/>
-        <texture file="skeletal/xion_elite_d_spec.png" name="specTex"/>
-    </textures>
+  <textures>
+    <texture file="skeletal/xion_advanced_g.png" name="baseTex"/>
+    <texture file="skeletal/xion_elite_d_spec.png" name="specTex"/>
+  </textures>
 </variant>
 

--- a/art/variants/clothes/xion/uniform_a_04.xml
+++ b/art/variants/clothes/xion/uniform_a_04.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <variant frequency="1" name="Cloth_H">
-    <textures>
-        <texture file="skeletal/xion_advanced_h.png" name="baseTex"/>
-        <texture file="skeletal/xion_elite_d_spec.png" name="specTex"/>
-    </textures>
+  <textures>
+    <texture file="skeletal/xion_advanced_h.png" name="baseTex"/>
+    <texture file="skeletal/xion_elite_d_spec.png" name="specTex"/>
+  </textures>
 </variant>

--- a/art/variants/clothes/xion/uniform_a_05.xml
+++ b/art/variants/clothes/xion/uniform_a_05.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <variant frequency="1" name="Cloth_A">
-    <textures>
-        <texture file="skeletal/xion_advanced_d.png" name="baseTex"/>
-        <texture file="skeletal/xion_advanced_norm.png" name="normTex"/>
-        <texture file="skeletal/xion_elite_spec.png" name="specTex"/>
-    </textures>
+  <textures>
+    <texture file="skeletal/xion_advanced_d.png" name="baseTex"/>
+    <texture file="skeletal/xion_advanced_norm.png" name="normTex"/>
+    <texture file="skeletal/xion_elite_spec.png" name="specTex"/>
+  </textures>
 </variant>

--- a/art/variants/clothes/xion/uniform_a_06.xml
+++ b/art/variants/clothes/xion/uniform_a_06.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <variant frequency="1" name="Cloth_B">
-    <textures>
-        <texture file="skeletal/xion_advanced_b.png" name="baseTex"/>
-        <texture file="skeletal/xion_advanced_norm.png" name="normTex"/>
-        <texture file="skeletal/xion_elite_spec.png" name="specTex"/>
-    </textures>
+  <textures>
+    <texture file="skeletal/xion_advanced_b.png" name="baseTex"/>
+    <texture file="skeletal/xion_advanced_norm.png" name="normTex"/>
+    <texture file="skeletal/xion_elite_spec.png" name="specTex"/>
+  </textures>
 </variant>

--- a/art/variants/clothes/xion/uniform_a_07.xml
+++ b/art/variants/clothes/xion/uniform_a_07.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <variant frequency="1" name="Cloth_C">
-    <textures>
-        <texture file="skeletal/xion_advanced_c.png" name="baseTex"/>
-        <texture file="skeletal/xion_advanced_norm.png" name="normTex"/>
-        <texture file="skeletal/xion_elite_spec.png" name="specTex"/>
-    </textures>
+  <textures>
+    <texture file="skeletal/xion_advanced_c.png" name="baseTex"/>
+    <texture file="skeletal/xion_advanced_norm.png" name="normTex"/>
+    <texture file="skeletal/xion_elite_spec.png" name="specTex"/>
+  </textures>
 </variant>

--- a/art/variants/clothes/xion/uniform_b_01.xml
+++ b/art/variants/clothes/xion/uniform_b_01.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <variant frequency="1" name="gray light">
-    <textures>
-        <texture file="skeletal/xion_cloth_a.png" name="baseTex"/>
-        <texture file="skeletal/xion_cloth_norm.png" name="specTex"/>
-        <texture file="skeletal/xion_cloth_spec.png" name="normTex"/>
-    </textures>
+  <textures>
+    <texture file="skeletal/xion_cloth_a.png" name="baseTex"/>
+    <texture file="skeletal/xion_cloth_norm.png" name="normTex"/>
+    <texture file="skeletal/xion_cloth_spec.png" name="specTex"/>
+  </textures>
 </variant>

--- a/art/variants/clothes/xion/uniform_b_02.xml
+++ b/art/variants/clothes/xion/uniform_b_02.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <variant frequency="1" name="brown dark">
-    <textures>
-        <texture file="skeletal/xion_cloth_b.png" name="baseTex"/>
-        <texture file="skeletal/xion_cloth_norm.png" name="specTex"/>
-        <texture file="skeletal/xion_cloth_spec.png" name="normTex"/>
-    </textures>
+  <textures>
+    <texture file="skeletal/xion_cloth_b.png" name="baseTex"/>
+    <texture file="skeletal/xion_cloth_norm.png" name="normTex"/>
+    <texture file="skeletal/xion_cloth_spec.png" name="specTex"/>
+  </textures>
 </variant>

--- a/art/variants/clothes/xion/uniform_b_03.xml
+++ b/art/variants/clothes/xion/uniform_b_03.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <variant frequency="1" name="brown light">
-    <textures>
-        <texture file="skeletal/xion_cloth_c.png" name="baseTex"/>
-        <texture file="skeletal/xion_cloth_norm.png" name="specTex"/>
-        <texture file="skeletal/xion_cloth_spec.png" name="normTex"/>
-    </textures>
+  <textures>
+    <texture file="skeletal/xion_cloth_c.png" name="baseTex"/>
+    <texture file="skeletal/xion_cloth_norm.png" name="normTex"/>
+    <texture file="skeletal/xion_cloth_spec.png" name="specTex"/>
+  </textures>
 </variant>

--- a/art/variants/clothes/xion/uniform_e_01.xml
+++ b/art/variants/clothes/xion/uniform_e_01.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <variant frequency="1" name="new-1">
-    <textures>
-        <texture file="skeletal/xion_elite_d.png" name="baseTex"/>
-        <texture file="skeletal/xion_elite_d_spec.png" name="specTex"/>
-    </textures>
+  <textures>
+    <texture file="skeletal/xion_elite_d.png" name="baseTex"/>
+    <texture file="skeletal/xion_elite_d_spec.png" name="specTex"/>
+  </textures>
 </variant>

--- a/art/variants/clothes/xion/uniform_e_02.xml
+++ b/art/variants/clothes/xion/uniform_e_02.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <variant frequency="1" name="new-2">
-    <textures>
-        <texture file="skeletal/xion_elite_e.png" name="baseTex"/>
-        <texture file="skeletal/xion_elite_e_spec.png" name="specTex"/>
-    </textures>
+  <textures>
+    <texture file="skeletal/xion_elite_e.png" name="baseTex"/>
+    <texture file="skeletal/xion_elite_e_spec.png" name="specTex"/>
+  </textures>
 </variant>

--- a/art/variants/clothes/xion/uniform_e_03.xml
+++ b/art/variants/clothes/xion/uniform_e_03.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <variant frequency="1" name="new-3">
-    <textures>
-        <texture file="skeletal/xion_elite_f.png" name="baseTex"/>
-        <texture file="skeletal/xion_elite_f_spec.png" name="specTex"/>
-    </textures>
+  <textures>
+    <texture file="skeletal/xion_elite_f.png" name="baseTex"/>
+    <texture file="skeletal/xion_elite_f_spec.png" name="specTex"/>
+  </textures>
 </variant>

--- a/art/variants/clothes/xion/uniform_e_04.xml
+++ b/art/variants/clothes/xion/uniform_e_04.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <variant frequency="1" name="new-4">
-    <textures>
-        <texture file="skeletal/xion_elite_g.png" name="baseTex"/>
-        <texture file="skeletal/xion_elite_f_spec.png" name="specTex"/>
-    </textures>
+  <textures>
+    <texture file="skeletal/xion_elite_g.png" name="baseTex"/>
+    <texture file="skeletal/xion_elite_f_spec.png" name="specTex"/>
+  </textures>
 </variant>

--- a/art/variants/clothes/xion/uniform_e_05.xml
+++ b/art/variants/clothes/xion/uniform_e_05.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <variant frequency="1" name="new-5">
-    <textures>
-        <texture file="skeletal/xion_elite_h.png" name="baseTex"/>
-        <texture file="skeletal/xion_elite_f_spec.png" name="specTex"/>
-    </textures>
+  <textures>
+    <texture file="skeletal/xion_elite_h.png" name="baseTex"/>
+    <texture file="skeletal/xion_elite_f_spec.png" name="specTex"/>
+  </textures>
 </variant>

--- a/art/variants/clothes/xion/warlord.xml
+++ b/art/variants/clothes/xion/warlord.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <variant>
-    <textures>
-        <texture file="skeletal/xion_warlord.png" name="baseTex"/>
-        <texture file="skeletal/xion_elite_norm.png" name="normTex"/>
-        <texture file="skeletal/xion_elite_spec.png" name="specTex"/>
-    </textures>
+  <textures>
+    <texture file="skeletal/xion_warlord.png" name="baseTex"/>
+    <texture file="skeletal/xion_elite_norm.png" name="normTex"/>
+    <texture file="skeletal/xion_elite_spec.png" name="specTex"/>
+  </textures>
 </variant>


### PR DESCRIPTION
**Correct all unit actor files:**
 - change and add some variants
 - correct attachpoints
 - correct indentation

**Correct several clothes-variants**
 - correct normTex<->specTex
 - correct indentation

**Create a file `..\art\skeletons\xion_bow.xml` file**
 - without this file several archer-units and also the barracks-structure would throw the error
> ERROR: art/meshes/props/weapons/bow/weap_xion_bow.dae: Assertion not satisfied (line 393): failed requirement "recognised skeleton structure"
 - if i.e. the mod Han_China is also activated the file would not be necessary, but if the player only activate the mod "Xiongnu" it would be necessary. It's a similar problem as with the Chariot's.

**There are several files with outcommented lines. I've leave them, because i don't know what was your intention to that.**
